### PR TITLE
checking in deletion of deprecated class 'last' in left sidebar html file

### DIFF
--- a/assets/templates/partials/common/left_sidebar.html
+++ b/assets/templates/partials/common/left_sidebar.html
@@ -26,7 +26,7 @@
         </li>
 
         <li ng-class="{active: leftSidebarCtrl.$state.includes('base.users.orders')}">
-          <a ui-sref="base.users.orders" class="li-links last">
+          <a ui-sref="base.users.orders" class="li-links">
             <span class="fa fa-clock-o left-tray-icon left-tray-menu-icon"></span>
             <span class="texts">ORDER HISTORY</span>
           </a>


### PR DESCRIPTION
Goes hand in hand with commit #193, where the class '.last'  was removed from the sass file. 