### PR TITLE
Fix disabled button issue with Create/Edit Products

### DIFF
--- a/assets/templates/partials/admin/products/create_product.html
+++ b/assets/templates/partials/admin/products/create_product.html
@@ -14,10 +14,10 @@
         </div>
       </div>
       <div ng-include src="'/partials/admin/products/_form.html'"></div>
+      <div class="col-sm-6 form-group">
+        <button type="submit" class="btn btn-primary" ng-disabled="!productForm.canSubmit()">CREATE PRODUCT</button>
+        <a ui-sref="base.authed.admin.products.list" class="btn btn-link">CANCEL</a>
+      </div>
     </form>
-    <div class="col-sm-6 form-group">
-      <button type="submit" class="btn btn-primary" ng-disabled="!productForm.canSubmit()">CREATE PRODUCT</button>
-      <a ui-sref="base.authed.admin.products.list" class="btn btn-link">CANCEL</a>
-    </div>
   </section-header>
 </div>

--- a/assets/templates/partials/admin/products/edit_product.html
+++ b/assets/templates/partials/admin/products/edit_product.html
@@ -14,11 +14,11 @@
         </div>
       </div>
       <div ng-include src="'/partials/admin/products/_form.html'"></div>
+      <div class="col-sm-6 form-group">
+        <button type="submit" class="btn btn-primary" ng-disabled="!productForm.canSubmit()">UPDATE</button>
+        <button type="button" class="btn btn-danger" ng-click="productForm.destroy()">DELETE PRODUCT</button>
+        <a ui-sref="base.authed.admin.products.list" class="btn btn-link">CANCEL</a>
+      </div>
     </form>
-    <div class="col-sm-6 form-group">
-      <button type="submit" class="btn btn-primary" ng-disabled="!productForm.canSubmit()">UPDATE</button>
-      <button type="button" class="btn btn-danger" ng-click="productForm.destroy()">DELETE PRODUCT</button>
-      <a ui-sref="base.authed.admin.products.list" class="btn btn-link">CANCEL</a>
-    </div>
   </section-header>
 </div>


### PR DESCRIPTION
- Moved buttons back into productForm scope.

Partially addressed the issue in #268. API no longer has a `products#create` route so creating products still fail.