### PR TITLE
Make appVersion available as an angular constant

### DIFF
--- a/assets/js/app/base/footer_controller.js
+++ b/assets/js/app/base/footer_controller.js
@@ -1,11 +1,11 @@
 'use strict';
 
 /**@ngInject*/
-var FooterController = function(footerLinks) {
+var FooterController = function(footerLinks, APP_VERSION) {
 
   this.footerLinks = footerLinks;
   this.copyrightYear = new Date();
-  this.jellyfishVersion = window.appVersion.ux;
+  this.jellyfishVersion = APP_VERSION.ux;
 };
 
 FooterController.resolve = {

--- a/assets/js/app/common/constants.js
+++ b/assets/js/app/common/constants.js
@@ -9,6 +9,7 @@ module.exports = angular.module('broker.common.constants', [])
     admin: 'admin'
   })
   .constant('APP_CONFIG', angular.copy(window.appConfig))
+  .constant('APP_VERSION', angular.copy(window.appVersion))
   .constant('ROUTES', {
     login: '/login',
     logout: '/logout',


### PR DESCRIPTION
Removes a global `window` use. Being done to clean up a testing issue and is also a good practice.